### PR TITLE
fix: auth buttons

### DIFF
--- a/src/components/atoms/Button.tsx
+++ b/src/components/atoms/Button.tsx
@@ -10,6 +10,7 @@ export interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
   isDeactivated?: boolean;
   px?: number;
   variant?: Exclude<keyof typeof buttonStyles, 'base'>;
+  onClick?: () => void;
 }
 
 const buttonStyles = {
@@ -40,6 +41,7 @@ export const Button: React.FC<ButtonProps> = (props: ButtonProps) => {
       className={styles}
       aria-label={props.ariaLabel || props.title}
       title={props.title}
+      onClick={() => (props.onClick ? props.onClick() : null)}
     >
       {props.children}
     </button>

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -48,7 +48,9 @@ const Home: PageWithLayout = () => {
               {!session && (
                 <>
                   <Button
-                    onClick={() => signIn('twitter')}
+                    onClick={() => {
+                      signIn('twitter');
+                    }}
                     title={'sign in'}
                     variant="primary"
                     className="mx-2"


### PR DESCRIPTION

Adds `onClick` as an attribute of the button component when used as a button, and not a link.

Resolves #17 
Many thanks to @TAKANOME-DEV for pointing out the problem in the issue.