### PR TITLE
fix: handle navbar responsivity

### DIFF
--- a/src/components/nav/AppNav.tsx
+++ b/src/components/nav/AppNav.tsx
@@ -1,10 +1,11 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { useRouter } from 'next/router';
 import Link from 'next/link';
 import * as Avatar from '@radix-ui/react-avatar';
 
 import { NavItem } from './NavItem';
 import { IconName, Icon } from '../atoms/Icon';
+import { useTailWindResponsive } from '../../hooks/useTailWindResponsive';
 
 type navLink = {
   href: string;
@@ -24,6 +25,12 @@ const navItems: navLink[] = [
 export const AppNav: React.FC<Record<string, unknown>> = () => {
   const router = useRouter();
   const [isOpen, setIsOpen] = React.useState(true);
+  const match = useTailWindResponsive('md');
+
+  useEffect(() => {
+    !match ? setIsOpen(false) : setIsOpen(true);
+  }, [match]);
+
   return (
     <section className={`p-4 md:max-w-xs bg-gray-800 ${isOpen ? 'w-64' : ''}`}>
       <header className="">

--- a/src/layouts/AppLayout.tsx
+++ b/src/layouts/AppLayout.tsx
@@ -16,6 +16,10 @@ export class AppLayout extends React.Component<LayoutProps> {
         <Head>
           <title>Shoutify</title>
           <meta
+            name="viewport"
+            content="width=device-width, initial-scale=1.0,  minimum-scale=1.0"
+          />
+          <meta
             name="description"
             content="Schedule and manage social media posts"
           />


### PR DESCRIPTION
This PR cover the following points:
- closed the menu if the screen size is less than `md:768px`
- handle the navbar extension to the full height of the screen

This PR Fixes #24 

![layout_1](https://user-images.githubusercontent.com/79809121/190923681-ce341913-143a-4a3c-a3ba-527f604864db.png)
![layout_2](https://user-images.githubusercontent.com/79809121/190923687-1c9c3aab-69af-43d9-a2fe-8d7fb2fca639.png)
